### PR TITLE
fix some misspellings from the comments and documentations

### DIFF
--- a/Sources/ModelsBuild/AdministrableProductDefinition.swift
+++ b/Sources/ModelsBuild/AdministrableProductDefinition.swift
@@ -50,7 +50,7 @@ open class AdministrableProductDefinition: DomainResource {
 	public var producedFrom: [Reference]?
 	
 	/// The ingredients of this administrable medicinal product. This is only needed if the ingredients are not
-	/// specified either using ManufacturedItemDefiniton, or using by incoming references from the Ingredient resource
+	/// specified either using ManufacturedItemDefinition, or using by incoming references from the Ingredient resource
 	public var ingredient: [CodeableConcept]?
 	
 	/// A device that is integral to the medicinal product, in effect being considered as an "ingredient" of the

--- a/Sources/ModelsBuild/BiologicallyDerivedProduct.swift
+++ b/Sources/ModelsBuild/BiologicallyDerivedProduct.swift
@@ -67,7 +67,7 @@ open class BiologicallyDerivedProduct: DomainResource {
 	/// Product storage temp requirements
 	public var storageTempRequirements: Range?
 	
-	/// A property that is specific to this BiologicallyDerviedProduct instance
+	/// A property that is specific to this BiologicallyDerivedProduct instance
 	public var property: [BiologicallyDerivedProductProperty]?
 	
 	/// Designated initializer taking all required properties

--- a/Sources/ModelsBuild/ClinicalUseDefinition.swift
+++ b/Sources/ModelsBuild/ClinicalUseDefinition.swift
@@ -215,10 +215,10 @@ open class ClinicalUseDefinitionContraindication: BackboneElement {
 	/// The status of the disease or symptom for the contraindication
 	public var diseaseStatus: CodeableReference?
 	
-	/// A comorbidity (concurrent condition) or coinfection
+	/// A comorbidity (concurrent condition) or confection
 	public var comorbidity: [CodeableReference]?
 	
-	/// The indication which this is a contraidication for
+	/// The indication which this is a contraindication for
 	public var indication: [Reference]?
 	
 	/// Information about the use of the medicinal product in relation to other therapies described as part of the

--- a/Sources/ModelsBuild/CodeSystemConceptProperties.swift
+++ b/Sources/ModelsBuild/CodeSystemConceptProperties.swift
@@ -31,7 +31,7 @@ public enum ConceptProperties: String, FHIRPrimitiveType {
 	/// will be 'code'. The meaning of 'child' is defined by the hierarchyMeaning attribute
 	case child
 	
-	/// A strng that provides additional detail pertinent to the use or understanding of the concept
+	/// A string that provides additional detail pertinent to the use or understanding of the concept
 	case comment
 	
 	/// The date at which a concept was deprecated. Concepts that are deprecated but not inactive can still be used, but

--- a/Sources/ModelsBuild/CodeSystemEligibilityRequestPurpose.swift
+++ b/Sources/ModelsBuild/CodeSystemEligibilityRequestPurpose.swift
@@ -27,15 +27,15 @@ import FMCore
  */
 public enum EligibilityRequestPurpose: String, FHIRPrimitiveType {
 	
-	/// The prior authorization requirements for the listed, or discovered if specified, converages for the categories
-	/// of service and/or specifed biling codes are requested.
+	/// The prior authorization requirements for the listed, or discovered if specified, coverages for the categories
+	/// of service and/or specified billing codes are requested.
 	case authRequirements = "auth-requirements"
 	
-	/// The plan benefits and optionally benefits consumed  for the listed, or discovered if specified, converages are
+	/// The plan benefits and optionally benefits consumed for the listed, or discovered if specified, coverages are
 	/// requested.
 	case benefits
 	
-	/// The insurer is requested to report on any coverages which they are aware of in addition to any specifed.
+	/// The insurer is requested to report on any coverages which they are aware of in addition to any specified.
 	case discovery
 	
 	/// A check that the specified coverages are in-force is requested.

--- a/Sources/ModelsBuild/CodeSystemEligibilityResponsePurpose.swift
+++ b/Sources/ModelsBuild/CodeSystemEligibilityResponsePurpose.swift
@@ -27,15 +27,15 @@ import FMCore
  */
 public enum EligibilityResponsePurpose: String, FHIRPrimitiveType {
 	
-	/// The prior authorization requirements for the listed, or discovered if specified, converages for the categories
-	/// of service and/or specifed biling codes are requested.
+	/// The prior authorization requirements for the listed, or discovered if specified, coverages for the categories
+	/// of service and/or specified billing codes are requested.
 	case authRequirements = "auth-requirements"
 	
-	/// The plan benefits and optionally benefits consumed  for the listed, or discovered if specified, converages are
+	/// The plan benefits and optionally benefits consumed  for the listed, or discovered if specified, coverages are
 	/// requested.
 	case benefits
 	
-	/// The insurer is requested to report on any coverages which they are aware of in addition to any specifed.
+	/// The insurer is requested to report on any coverages which they are aware of in addition to any specified.
 	case discovery
 	
 	/// A check that the specified coverages are in-force is requested.

--- a/Sources/ModelsBuild/CodeSystemInvoiceStatus.swift
+++ b/Sources/ModelsBuild/CodeSystemInvoiceStatus.swift
@@ -27,7 +27,7 @@ import FMCore
  */
 public enum InvoiceStatus: String, FHIRPrimitiveType {
 	
-	/// the invoice has been balaced / completely paid.
+	/// the invoice has been balanced / completely paid.
 	case balanced
 	
 	/// the invoice was cancelled.

--- a/Sources/ModelsBuild/CodeSystemMedicationDispenseStatusReasonCodes.swift
+++ b/Sources/ModelsBuild/CodeSystemMedicationDispenseStatusReasonCodes.swift
@@ -90,7 +90,7 @@ public enum MedicationDispenseStatusReasonCodes: String, FHIRPrimitiveType {
 	case sddi
 	
 	/// Another short-term co-occurring therapy fulfills the same purpose as this therapy. This therapy will be resumed
-	/// when the co-occuring therapy is complete.
+	/// when the co-occurring therapy is complete.
 	case sdupther
 	
 	/// The patient is believed to have an intolerance to a substance that is part of the therapy and the therapy is

--- a/Sources/ModelsBuild/CodeSystemNamingSystemIdentifierType.swift
+++ b/Sources/ModelsBuild/CodeSystemNamingSystemIdentifierType.swift
@@ -39,7 +39,7 @@ public enum NamingSystemIdentifierType: String, FHIRPrimitiveType {
 	/// A universally unique identifier of the form a5afddf4-e880-459b-876e-e4591b0acc11.
 	case uuid
 	
-	/// A short string published by HL7 for use in the V2 family of standsrds to idenfify a code system in the V12 coded
+	/// A short string published by HL7 for use in the V2 family of standards to identify a code system in the V12 coded
 	/// data types CWE, CNE, and CF. The code values are also published by HL7 at
 	/// http://www.hl7.org/Special/committees/vocab/table_0396/index.cfm
 	case v2csmnemonic

--- a/Sources/ModelsBuild/CodeSystemPackageType.swift
+++ b/Sources/ModelsBuild/CodeSystemPackageType.swift
@@ -20,7 +20,7 @@
 import FMCore
 
 /**
- A high level categorisation of a package.
+ A high level categorization of a package.
  
  URL: http://hl7.org/fhir/package-type
  ValueSet: http://hl7.org/fhir/ValueSet/package-type

--- a/Sources/ModelsBuild/CodeSystemProductContactType.swift
+++ b/Sources/ModelsBuild/CodeSystemProductContactType.swift
@@ -33,12 +33,12 @@ public enum ProductContactType: String, FHIRPrimitiveType {
 	/// Pharmacovigilance Enquiry Information
 	case pVEnquiries = "PVEnquiries"
 	
-	/// Person/Company authorised for Communication between MAH and Authorities after Authorisation
+	/// Person/Company authorized for Communication between MAH and Authorities after Authorization
 	case procedureContactAfter = "ProcedureContactAfter"
 	
-	/// Person/Company authorised for Communication on behalf of the Applicant during the Procedure
+	/// Person/Company authorized for Communication on behalf of the Applicant during the Procedure
 	case procedureContactDuring = "ProcedureContactDuring"
 	
-	/// Proposed Marketing Authorisation Holder/Person
+	/// Proposed Marketing Authorization Holder/Person
 	case proposedMAH = "ProposedMAH"
 }

--- a/Sources/ModelsBuild/CodeSystemResearchSubjectStateType.swift
+++ b/Sources/ModelsBuild/CodeSystemResearchSubjectStateType.swift
@@ -34,6 +34,6 @@ public enum ResearchSubjectStateType: String, FHIRPrimitiveType {
 	/// One of a set of milestone events that once they have occurred remain true thereafter.  For example once a
 	/// subject has reached the "Signed Informed Consent" milestone they achieve a status of "Consented" that will be
 	/// true thereafter, even when they have left the study.  For a subject a number of these states can be
-	/// simulataneously true and should be recorded.
+	/// simultaneously true and should be recorded.
 	case milestone = "Milestone"
 }

--- a/Sources/ModelsBuild/CodeSystemResourceSecurityCategory.swift
+++ b/Sources/ModelsBuild/CodeSystemResourceSecurityCategory.swift
@@ -59,7 +59,7 @@ public enum ResourceSecurityCategory: String, FHIRPrimitiveType {
 	case notClassified = "not-classified"
 	
 	/// These Resources make up the bulk of FHIR and therefore are the most commonly understood. These Resources contain
-	/// highly sesitive health information, or are closely linked to highly sensitive health information. These
+	/// highly sensitive health information, or are closely linked to highly sensitive health information. These
 	/// Resources will often use the security labels to differentiate various confidentiality levels within this broad
 	/// group of Patient Sensitive data. Access to these Resources often requires a declared Purpose Of Use. Access to
 	/// these Resources is often controlled by a Privacy Consent.

--- a/Sources/ModelsBuild/CodeSystemStructureDefinitionKind.swift
+++ b/Sources/ModelsBuild/CodeSystemStructureDefinitionKind.swift
@@ -39,10 +39,10 @@ public enum StructureDefinitionKind: String, FHIRPrimitiveType {
 	/// extension definitions. Only the base specification can define primitive types.
 	case primitiveType = "primitive-type"
 	
-	/// A 'resource' - a directed acyclic graph of elements that aggregrates other types into an identifiable entity.
+	/// A 'resource' - a directed acyclic graph of elements that aggregates other types into an identifiable entity.
 	/// The base FHIR resources are defined by the FHIR specification itself but other 'resources' can be defined in
-	/// additional specifications (though these will not be recognised as 'resources' by the FHIR specification (i.e.
+	/// additional specifications (though these will not be recognized as 'resources' by the FHIR specification (i.e.
 	/// they do not get end-points etc, or act as the targets of references in FHIR defined resources - though other
-	/// specificatiosn can treat them this way).
+	/// specifications can treat them this way).
 	case resource
 }

--- a/Sources/ModelsBuild/CoverageEligibilityRequest.swift
+++ b/Sources/ModelsBuild/CoverageEligibilityRequest.swift
@@ -36,7 +36,7 @@ open class CoverageEligibilityRequest: DomainResource {
 		case period(Period)
 	}
 	
-	/// Business Identifier for coverage eligiblity request
+	/// Business Identifier for coverage eligibility request
 	public var identifier: [Identifier]?
 	
 	/// The status of the resource instance.

--- a/Sources/ModelsBuild/CoverageEligibilityResponse.swift
+++ b/Sources/ModelsBuild/CoverageEligibilityResponse.swift
@@ -34,7 +34,7 @@ open class CoverageEligibilityResponse: DomainResource {
 		case period(Period)
 	}
 	
-	/// Business Identifier for coverage eligiblity request
+	/// Business Identifier for coverage eligibility request
 	public var identifier: [Identifier]?
 	
 	/// The status of the resource instance.

--- a/Sources/ModelsBuild/SubscriptionStatus.swift
+++ b/Sources/ModelsBuild/SubscriptionStatus.swift
@@ -31,7 +31,7 @@ open class SubscriptionStatus: DomainResource {
 	/// The status of the subscription, which marks the server state for managing the subscription.
 	public var status: FHIRPrimitive<SubscriptionStatusCodes>?
 	
-	/// The type of event being conveyed with this notificaiton.
+	/// The type of event being conveyed with this notification.
 	public var type: FHIRPrimitive<SubscriptionNotificationType>
 	
 	/// Events since the Subscription was created

--- a/Sources/ModelsBuild/SubstancePolymer.swift
+++ b/Sources/ModelsBuild/SubstancePolymer.swift
@@ -26,7 +26,7 @@ open class SubstancePolymer: DomainResource {
 	
 	override open class var resourceType: ResourceType { return .substancePolymer }
 	
-	/// A business idenfier for this polymer, but typically this is handled by a SubstanceDefinition identifier
+	/// A business identifier for this polymer, but typically this is handled by a SubstanceDefinition identifier
 	public var identifier: Identifier?
 	
 	/// Overall type of the polymer

--- a/Sources/ModelsR4/PaymentNotice.swift
+++ b/Sources/ModelsR4/PaymentNotice.swift
@@ -29,7 +29,7 @@ open class PaymentNotice: DomainResource {
 	
 	override open class var resourceType: ResourceType { return .paymentNotice }
 	
-	/// Business Identifier for the payment noctice
+	/// Business Identifier for the payment notice
 	public var identifier: [Identifier]?
 	
 	/// The status of the resource instance.

--- a/Sources/ModelsR4/Population.swift
+++ b/Sources/ModelsR4/Population.swift
@@ -23,7 +23,7 @@ import FMCore
  A definition of a set of people that apply to some clinically related context, for example people contraindicated for a
  certain medication.
  
- A populatioof people with some set of grouping criteria.
+ A population of people with some set of grouping criteria.
  */
 open class Population: BackboneElement {
 	

--- a/Sources/ModelsR4/Practitioner.swift
+++ b/Sources/ModelsR4/Practitioner.swift
@@ -198,7 +198,7 @@ open class Practitioner: DomainResource {
  
  The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the
  practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice
- medicine within a certian locality.
+ medicine within a certain locality.
  */
 open class PractitionerQualification: BackboneElement {
 	


### PR DESCRIPTION
- No code change, just comments.
- Some of them are referencing invalid names like `BiologicallyDerivedProduct`
- Some of the comments are misspelled but the actual code is using the misspelled too! No changes to the codes and corresponding documentation