### PR TITLE
Build fix for Swift on Windows

### DIFF
--- a/Sources/FMCore/Scanner+FHIR.swift
+++ b/Sources/FMCore/Scanner+FHIR.swift
@@ -21,7 +21,7 @@ import Foundation
 public extension Scanner {
 	
 	func hs_scanCharacters(from characterSet: CharacterSet) -> String? {
-		#if os(Linux)
+		#if os(Linux) || os(Windows)
 		return scanCharacters(from: characterSet)
 		#else
         


### PR DESCRIPTION
FHIRModels does not compile on Windows, currently. Just a small fix makes it work for Swift 6 on Windows.